### PR TITLE
feat: config for sqlite-only store

### DIFF
--- a/ansible/group_vars/status.yml
+++ b/ansible/group_vars/status.yml
@@ -14,7 +14,10 @@ nim_waku_rpc_tcp_port: 8545
 nim_waku_rpc_tcp_addr: 0.0.0.0
 # Limits
 nim_waku_p2p_max_connections: 150
-nim_waku_store_capacity: 100000
+
+# SQLite store
+nim_waku_sqlite_store: true
+nim_waku_sqlite_retention_time: 30.days.seconds
 # Peer connecting
 nim_waku_connect_consul_service_names: ['{{ nim_waku_cont_name }}', 'nim-waku-bridge']
 nim_waku_connect_rpc_port: '{{ nim_waku_rpc_tcp_port }}'

--- a/ansible/group_vars/status.yml
+++ b/ansible/group_vars/status.yml
@@ -14,10 +14,9 @@ nim_waku_rpc_tcp_port: 8545
 nim_waku_rpc_tcp_addr: 0.0.0.0
 # Limits
 nim_waku_p2p_max_connections: 150
-
 # SQLite store
 nim_waku_sqlite_store: true
-nim_waku_sqlite_retention_time: 30.days.seconds
+nim_waku_sqlite_retention_time: '30.days.seconds'
 # Peer connecting
 nim_waku_connect_consul_service_names: ['{{ nim_waku_cont_name }}', 'nim-waku-bridge']
 nim_waku_connect_rpc_port: '{{ nim_waku_rpc_tcp_port }}'


### PR DESCRIPTION
Configures the SQLite only store on the Status nwaku fleets.

This requires `v0.10` to be deployed. Depends on the related role PR: https://github.com/status-im/infra-role-nim-waku/pull/2