### PR TITLE
Increase store node retention to 30 days

### DIFF
--- a/ansible/group_vars/status.yml
+++ b/ansible/group_vars/status.yml
@@ -20,7 +20,7 @@ nim_waku_rpc_tcp_addr: 0.0.0.0
 nim_waku_p2p_max_connections: 150
 # SQLite store
 nim_waku_sqlite_store: true
-nim_waku_sqlite_retention_time: 1209600 # 14 days
+nim_waku_sqlite_retention_time: 2592000 # 30 days
 # Discovery V5
 nim_waku_disc_v5_enabled: true
 nim_waku_disc_v5_enr_auto_update: true


### PR DESCRIPTION
## Why

> The status products are built around a number of time based message availability assumptions (a legacy of the waku v1 30 day message persistence guarantee). As we move to waku v2, it is vitally important that waku v2 store nodes have the ability to offer the same time based guarantees that waku v1 mailserver nodes offered.
> 
> – https://docs.google.com/document/d/1it9_HTzOTvumBsUoeY3SEVFTJA-sSYrW89-HsEjriEg/edit?usp=sharing