### PR TITLE
fix: bridge log-level config should be uppercase

### DIFF
--- a/ansible/roles/nim-waku-bridge/templates/docker-compose.yml.j2
+++ b/ansible/roles/nim-waku-bridge/templates/docker-compose.yml.j2
@@ -16,7 +16,7 @@ services:
       - '{{ nim_waku_bridge_metrics_port }}:{{ nim_waku_bridge_metrics_port }}/tcp'
       - '{{ nim_waku_bridge_rpc_tcp_addr }}:{{ nim_waku_bridge_rpc_tcp_port }}:{{ nim_waku_bridge_rpc_tcp_port }}/tcp'
     command: |
-      --log-level={{ nim_waku_bridge_log_level }}
+      --log-level={{ nim_waku_bridge_log_level | upper }}
       --relay
       --listen-address=0.0.0.0
       --libp2p-tcp-port={{ nim_waku_bridge_libp2p_port }}


### PR DESCRIPTION
Following [similar config](https://github.com/status-im/infra-role-nim-waku/blob/5cb823718fce1725303ef7a3584d98a4151b4301/templates/docker-compose.yml.j2#L88) for the rest of the fleets.