### PR TITLE
chore: disable filter and lightpush on prod

### DIFF
--- a/ansible/group_vars/status.yml
+++ b/ansible/group_vars/status.yml
@@ -7,7 +7,7 @@ nim_waku_cont_name: 'nim-waku'
 nim_waku_log_level: 'debug'
 nim_waku_dns4_domain_name: '{{ dns_entry }}'
 # Protocols
-nim_waku_protocols_enabled: ['relay', 'filter', 'lightpush', 'store']
+nim_waku_protocols_enabled: '{{ ["relay", "store"] if stage == "prod" else ["relay", "filter", "lightpush", "store"] }}'
 # Node Key
 nim_waku_node_key: '{{lookup("bitwarden", "fleets/status/"+stage+"/nodekeys", field=hostname)}}'
 # Ports


### PR DESCRIPTION
Filter and Lightpush are both in alpha state and should not be enabled on `status.prod`.

Not sure if this is the best way to make the config change. I believe this may also affect what protocols the [canary service](https://canary.infra.status.im/service/82/) for `status.prod` tries to create connections for.