### PR TITLE
status-prod: increase volume size

### DIFF
--- a/workspaces.tf
+++ b/workspaces.tf
@@ -26,7 +26,7 @@ locals {
     test = { hosts_count = 1 }
     prod = {
       hosts_count = 2
-      data_volume_size = 80
+      data_volume_size = 100
     }
   }
 }


### PR DESCRIPTION
Increasing by 20GB the volume to temporary fix the `status.prod` fleet.

