### PR TITLE
status-prod: increase data size

### DIFF
--- a/workspaces.tf
+++ b/workspaces.tf
@@ -26,7 +26,7 @@ locals {
     test = { hosts_count = 1 }
     prod = {
       hosts_count = 2
-      data_volume_size = 100
+      data_volume_size = 350
     }
   }
 }


### PR DESCRIPTION
Increase the size of the volume size to allow manual vacuum of `status-prod` fleet